### PR TITLE
getAccountCloneString() cannot read fields of the instance in getAccountCloneString()

### DIFF
--- a/src/test/env.ts
+++ b/src/test/env.ts
@@ -71,7 +71,8 @@ export class SwitchboardTestEnvironment implements ISwitchboardTestEnvironment {
 
   private getAccountCloneString(): string {
     const accounts: string[] = Object.entries(this).map(
-      (key: any, val: any) => {
+      (field: any[]) => {
+        const [key, val] = field;
         // iterate over additionalClonedAccounts and collect pubkeys
         if (key === "additionalClonedAccounts" && val) {
           const additionalPubkeys = Object.values(


### PR DESCRIPTION
When use Object.entries on an instance it will return array of array

[playground link](https://www.typescriptlang.org/play?#code/MYGwhgzhAEDKD2BbApgYXFA6gSwC4AsAxbZEAExgG8AoaO6AMxPIEYAuaCXAJ2wDsA5gG5a9JqTIAmDnwCuiAEbJuI0XWDw+XbrOC543ABQBKaDXoXoBbBAB041tAC80AEQA3MCFnIWrkZb01nYOUs7QkgAMAfQAvtTx1BpauND8XGB8wMjhfMgA7nBIaBgQOATEEhAmqskQ8CDItiDwAoYA8goAVsh6tsh8PCTV6biZ2cbGqp09fQNDyCMp48jGtohgAA6GatCGANbIAJ4ANNCeIKZOAHzQdQ1NLW0ABodHHAAklG+xZxeflAusWexmooKAA)

Example:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/1768460/167377915-31980fe0-b7e6-4228-bc71-ac6cfb1eecbd.png">

Result:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/1768460/167377949-764b0914-63bd-4b57-acbb-a4d4fe68e9b7.png">

with this result getAccountCloneString will not write the appropriate account to the file.
